### PR TITLE
BREAKING: Update buffer to ^6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "browser-pack": "^6.0.1",
     "browser-resolve": "^2.0.0",
     "browserify-zlib": "~0.2.0",
-    "buffer": "~5.2.1",
+    "buffer": "^6.0.3",
     "cached-path-relative": "^1.0.0",
     "concat-stream": "^1.6.0",
     "console-browserify": "^1.1.0",


### PR DESCRIPTION
BREAKING: Drop IE11, Safari 9-10 support

Since Buffer now supports the BigInt methods and the code for that uses the exponentiation operator, we decided to drop support for IE11 and Safari 9-10 from `buffer`.